### PR TITLE
fix: fix send layer timings

### DIFF
--- a/Packages/befuddledlabs.opensyncdance/Runtime/OpenSyncDance.cs
+++ b/Packages/befuddledlabs.opensyncdance/Runtime/OpenSyncDance.cs
@@ -475,10 +475,13 @@ namespace BefuddledLabs.OpenSyncDance
 
                 void SoundAnimation(AacFlEditClip a, SyncedAnimation an, float startVolume)
                 {
-                    if (_audioSource) {
+                    if (_audioSource)
+                    {
                         var volume = a.AnimatesAnimator(songVolumeParam);
-                        volume.WithUnit(AacFlUnit.Seconds, key => {
-                            if (startVolume >= 0) {
+                        volume.WithUnit(AacFlUnit.Seconds, key =>
+                        {
+                            if (startVolume >= 0)
+                            {
                                 var endTime = 0.2f;
                                 if (an.animationClip)
                                     endTime = Mathf.Min(an.animationClip.length, endTime);
@@ -491,6 +494,11 @@ namespace BefuddledLabs.OpenSyncDance
                             }
                         });
                     }
+                    a.Animates(gameObject).WithUnit(AacFlUnit.Seconds, k =>
+                    {
+                        if (an.animationClip)
+                            k.Constant(an.animationClip.length, 1);
+                    });
                 }
 
                 AacFlClip CreateClip(SyncedAnimation an, float startVolume = -1) =>
@@ -511,13 +519,13 @@ namespace BefuddledLabs.OpenSyncDance
 
                 // anim entry (with early exit)
                 entryMusicState.TransitionsTo(exitMusicState).When(_paramSendAnimId.IsNotEqualTo(i));
-                entryMusicState.TransitionsTo(loopMusicState).Automatically();
+                entryMusicState.TransitionsTo(loopMusicState).AfterAnimationFinishes();
 
                 // anim loop
                 loopMusicState.TransitionsTo(exitMusicState).When(_paramSendAnimId.IsNotEqualTo(i));
 
                 // anim exit
-                exitMusicState.TransitionsTo(exitState).Automatically();
+                exitMusicState.TransitionsTo(exitState).AfterAnimationFinishes();
             }
         }
 

--- a/Packages/befuddledlabs.opensyncdance/package.json
+++ b/Packages/befuddledlabs.opensyncdance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "befuddledlabs.opensyncdance",
   "displayName": "Open Sync Dance",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "url": "https://github.com/BefuddledLabs/OpenSyncDance",
   "author": {
     "name": "BefuddledLabs"
@@ -10,7 +10,7 @@
   "description": "Silly synchronized dances for all!",
   "vpmDependencies": {
     "com.vrchat.avatars": "^3.1.0",
-    "dev.hai-vr.animator-as-code.v1": "^1.1.0",
-    "dev.hai-vr.animator-as-code.v1.vrchat": "^1.1.0"
+    "dev.hai-vr.animator-as-code.v1": "^1.2.0",
+    "dev.hai-vr.animator-as-code.v1.vrchat": "^1.1.2"
   }
 }


### PR DESCRIPTION
Fixes a bug where the loop/exit audio would play prematurely due to the animation transitioning into those states not matching the emote animation length.